### PR TITLE
Fix the case where `each` is at the root of a template

### DIFF
--- a/lib/utils/compiler.js
+++ b/lib/utils/compiler.js
@@ -42,7 +42,7 @@ Compiler.prototype.compile = function(){
       }
     }
   }
-  this.buf.push('if (tags.length === 1) { return tags.pop() };');
+  this.buf.push('if (tags.length === 1 && !Array.isArray(tags[0])) { return tags.pop() };');
   this.buf.push('tags.unshift("div", null);');
   this.buf.push('return React.createElement.apply(React, tags);');
   this.buf.push('}.call(this));');


### PR DESCRIPTION
In this situation, the template must be wrapped in a `div` because
react does not allow you to return multiple elements.