### PR TITLE
Support using this in mixins

### DIFF
--- a/lib/utils/compiler.js
+++ b/lib/utils/compiler.js
@@ -135,7 +135,7 @@ Compiler.prototype.visitLiteral = function (literal) {
   }
 };
 Compiler.prototype.visitMixinBlock = function(block){
-    this.buf.push('block && (tags = tags.concat(block()));');
+    this.buf.push('block && (tags = tags.concat(block.call(this)));');
 };
 
 
@@ -157,7 +157,7 @@ Compiler.prototype.visitMixin = function(mixin) {
       //if (pp) this.buf.push("jade_indent.push('" + Array(this.indents + 1).join('  ') + "');")
       if (block || attrs.length || attrsBlocks.length) {
 
-        this.buf.push('tags = tags.concat(' + name + '.call({');
+        this.buf.push('tags = tags.concat(' + name + '.call(this, {');
 
         if (block) {
           this.buf.push('block: function(){');
@@ -191,7 +191,12 @@ Compiler.prototype.visitMixin = function(mixin) {
         }
 
       } else {
-        this.buf.push('tags = tags.concat(' + name + '.apply(this,[' + args + ']));');
+        this.buf.push('tags = tags.concat(' + name + '.call(this, {}');
+        if (args) {
+          this.buf.push(', ' + args + '));');
+        } else {
+          this.buf.push('));');
+        }
       }
     } else {
       var mixin_start = this.buf.length;
@@ -200,8 +205,10 @@ Compiler.prototype.visitMixin = function(mixin) {
       if (args.length && /^\.\.\./.test(args[args.length - 1].trim())) {
         rest = args.pop().trim().replace(/^\.\.\./, '');
       }
-      this.buf.push(name + ' = function(' + args.join(',') + '){');
-      this.buf.push('var block = (this && this.block), attributes = (this && this.attributes) || {};');
+      this.buf.push(name + ' = function(jade_mixin_options');
+      if (args.length) this.buf.push(',' + args.join(','));
+      this.buf.push('){');
+      this.buf.push('var block = (jade_mixin_options && jade_mixin_options.block), attributes = (jade_mixin_options && jade_mixin_options.attributes) || {};');
       if (rest) {
         this.buf.push('var ' + rest + ' = [];');
         this.buf.push('for (jade_interp = ' + args.length + '; jade_interp < arguments.length; jade_interp++) {');

--- a/lib/utils/compiler.js
+++ b/lib/utils/compiler.js
@@ -211,7 +211,7 @@ Compiler.prototype.visitMixin = function(mixin) {
       this.buf.push('var block = (jade_mixin_options && jade_mixin_options.block), attributes = (jade_mixin_options && jade_mixin_options.attributes) || {};');
       if (rest) {
         this.buf.push('var ' + rest + ' = [];');
-        this.buf.push('for (jade_interp = ' + args.length + '; jade_interp < arguments.length; jade_interp++) {');
+        this.buf.push('for (jade_interp = ' + (args.length + 1) + '; jade_interp < arguments.length; jade_interp++) {');
         this.buf.push('  ' + rest + '.push(arguments[jade_interp]);');
         this.buf.push('}');
       }


### PR DESCRIPTION
This is a breaking change if anyone was using `arguments` within a mixin because it adds `jade_mixin_options` as the first argument, which must then be ignored.  This will therefore need to be released as 3.0.0