### PR TITLE
Use with module from npm to handle global variable detection

### DIFF
--- a/lib/parse.js
+++ b/lib/parse.js
@@ -5,6 +5,7 @@ var assert = require('assert');
 var uglify = require('uglify-js');
 var Parser = require('jade/lib/parser.js');
 var jade = require('jade/lib/runtime.js');
+var addWith = require('with');
 var Compiler = require('./utils/compiler.js');
 var JavaScriptCompressor = require('./utils/java-script-compressor.js');
 
@@ -26,25 +27,18 @@ function parse(str, options) {
   }
   var compiler = new Compiler(tokens);
 
-  var js = 'var fn = function (locals) {' +
-    jade_join_classes + ';' +
-    jade_fix_style + ';' +
-    'var jade_mixins = {};' +
-    'var jade_interp;' +
-    'jade_variables(locals);' +
-    compiler.compile() +
-    '}';
+  var src = compiler.compile();
+  src = [
+    jade_join_classes + ';',
+    jade_fix_style + ';',
+    'var jade_mixins = {};',
+    'var jade_interp;',
+    src
+  ].join('\n')
 
-  // Check that the compiled JavaScript code is valid thus far.
-  // uglify-js throws very cryptic errors when it fails to parse code.
-  try {
-    Function('', js);
-  } catch (ex) {
-    console.log(js);
-    throw ex;
-  }
-
-  var ast = uglify.parse(js, {filename: options.filename});
+  var ast = uglify.parse(';(function () {' + src + '}.call(this));', {
+    filename: options.filename
+  });
 
   ast.figure_out_scope();
   ast = ast.transform(uglify.Compressor({
@@ -70,25 +64,43 @@ function parse(str, options) {
 
   ast = ast.transform(new JavaScriptCompressor());
 
-  ast.figure_out_scope();
-  var globals = ast.globals.map(function (node, name) {
-    return name;
-  }).filter(function (name) {
-    return name !== 'jade_variables' && name !== 'exports' && name !== 'Array' && name !== 'Object'
-      && name !== 'React';
-  });
+  src = ast.body[0].body.expression.expression.body.map(function (statement) {
+    return statement.print_to_string({
+      beautify: true,
+      comments: true,
+      indent_level: 2
+    });
+  }).join('\n');
+  src = addWith('locals || {}', src, [
+    'tags',
+    'React',
+    'Array',
+    'undefined'
+  ]);
+  var js = 'var fn = function (locals) {' +
+    'var tags = [];' +
+    src +
+    'if (tags.length === 1 && !Array.isArray(tags[0])) { return tags.pop() };' +
+    'tags.unshift("div", null);' +
+    'return React.createElement.apply(React, tags);' +
+    '}';
 
+  // Check that the compiled JavaScript code is valid thus far.
+  // uglify-js throws very cryptic errors when it fails to parse code.
+  try {
+    Function('', js);
+  } catch (ex) {
+    console.log(js);
+    throw ex;
+  }
+
+  var ast = uglify.parse(js + ';\nfn.locals = ' + setLocals + ';', {
+    filename: options.filename
+  });
   js = ast.print_to_string({
     beautify: true,
     comments: true,
     indent_level: 2
   });
-  assert(/jade_variables\(locals\)/.test(js));
-
-  js = js.replace(/\n? *jade_variables\(locals\);?/, globals.map(function (g) {
-    return '  var ' + g + ' = ' + JSON.stringify(g) + ' in locals ? locals.' + g + ' : jade_globals_' + g + ';';
-  }).join('\n'));
-  return globals.map(function (g) {
-    return 'var jade_globals_' + g + ' = typeof ' + g + ' === "undefined" ? undefined : ' + g + ';\n';
-  }).join('') + js + ';\nfn.locals = ' + setLocals + ';\nreturn fn;';
+  return js + ';\nreturn fn;';
 }

--- a/lib/utils/compiler.js
+++ b/lib/utils/compiler.js
@@ -25,7 +25,6 @@ function Compiler(node) {
 
 Compiler.prototype.compile = function(){
   this.buf = [];
-  this.buf.push('return (function () {var tags = [];');
   this.visit(this.node);
 
   if (!this.dynamicMixins) {
@@ -42,10 +41,6 @@ Compiler.prototype.compile = function(){
       }
     }
   }
-  this.buf.push('if (tags.length === 1 && !Array.isArray(tags[0])) { return tags.pop() };');
-  this.buf.push('tags.unshift("div", null);');
-  this.buf.push('return React.createElement.apply(React, tags);');
-  this.buf.push('}.call(this));');
   return this.buf.join('\n');
 };
 Compiler.prototype.visit = function(node){

--- a/lib/utils/java-script-compressor.js
+++ b/lib/utils/java-script-compressor.js
@@ -76,6 +76,7 @@ function isArrayPush(node, name) {
 // for `function () { var arr = []; arr.push(...); arr.push(...); return arr;}` get `[..., ...]`
 function getReturnStatement(node) {
   var nodes = node.body;
+  if (nodes.length === 0) return new uglify.AST_Undefined({});
   if (nodes[0].TYPE === 'Var' && nodes[0].definitions.length === 1 && nodes[0].definitions[0].value.TYPE === 'Array') {
     var name = nodes[0].definitions[0].name.name;
     var array = nodes[0].definitions[0].value;

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "jade": "1.7.0",
     "resolve": "^1.0.0",
     "static-module": "^1.0.0",
-    "uglify-js": "^2.4.15"
+    "uglify-js": "^2.4.15",
+    "with": "^4.0.1"
   },
   "devDependencies": {
     "es6ify": "^1.5.1",


### PR DESCRIPTION
This is a much better match for jade because it means we pick up the
globals at the time that the function is called, rather than when it is
first defined.

It’s also nice to leave the heavy lifting to the `with` module rather
than trying to do it ourselves.