### PR TITLE
Add two-way-binding support for checkedLink

### DIFF
--- a/lib/utils/compiler.js
+++ b/lib/utils/compiler.js
@@ -293,7 +293,7 @@ function getAttributes(attrs){
         }
       }
     }
-    if (key === 'valueLink') {
+    if (/Link$/.test(key)) {
       // transform: valueLink = this.state.name
       // into:      valueLink = {value: this.state.name,requestChange:function(v){ this.setState({name:v})}.bind(this)}
       var ast = uglify.parse('jade_interp = (' + attr.val + ')');


### PR DESCRIPTION
[closes #26]

This actually applies the same transformation to any attribute of the form `fooLink`