### PR TITLE
Fixed jade syntax in ES6 example

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,8 @@ If you are using ES6 server side, or the browserify transform client side (even 
 var TodoList = React.createClass({
   render: jade`
 ul
-  each item in this.props.items
+  - each item in this.props.items
+    li= item
 `
 });
 var TodoApp = React.createClass({


### PR DESCRIPTION
I actually tried the example using webpack and got an expected "indent", but got "outdent" error